### PR TITLE
Add Big-Endian support in verifyColorGradient

### DIFF
--- a/external/openglcts/modules/common/glcPackedDepthStencilTests.cpp
+++ b/external/openglcts/modules/common/glcPackedDepthStencilTests.cpp
@@ -1003,6 +1003,12 @@ bool BaseTest::verifyColorGradient(GLvoid* data, unsigned int texIndex, int func
 			skip			= 0;
 			GLuint color	= ((GLuint*)data)[index];
 			GLuint colorref = 0;
+			
+// When data back from glReadPixels with arguments GL_RGBA + GL_UNSIGNED_BYTE,
+// we should reverse byte order in big-endian platform for (GLuint*) pointer.
+#if (DE_ENDIANNESS == DE_BIG_ENDIAN)
+            color = deReverseBytes32(color);
+#endif			
 
 			switch (texIndex)
 			{


### PR DESCRIPTION
When data back from glReadPixels with arguments GL_RGBA + GL_UNSIGNED_BYTE, we use GLvoid* data to get color buffer address and then use (GLuint*) to get value color.

But the reference value colorref is generated by little-endian logic, we should convert value color to LSB order or colorref to MSB order in big-endian platform.

Fix issue: https://github.com/KhronosGroup/VK-GL-CTS/issues/252